### PR TITLE
WIP: on_display/on_init allowing templates without elements.

### DIFF
--- a/rapido/core/tests/base.py
+++ b/rapido/core/tests/base.py
@@ -169,6 +169,8 @@ elements:
 def message(context):
     return "bacon"
 """,
+
+    'html': lambda elements, context, **v: 'France is ' + elements['message']
 }
 
 FAKE9 = {
@@ -246,10 +248,8 @@ class SimpleRapidoApplication(BaseNode):
         return self.settings
 
     def get_block(self, block_id, ftype='yaml'):
-        if block_id == 'frmBook8' and ftype == 'html':
-            return lambda elements, context: 'France is ' + elements['message']
         if block_id in self.fake_blocks:
-            return self.fake_blocks[block_id][ftype]
+            return self.fake_blocks[block_id].get(ftype,"")
         else:
             if ftype == 'yaml':
                 return 'id: ' + block_id

--- a/rapido/core/tests/test_block.py
+++ b/rapido/core/tests/test_block.py
@@ -9,6 +9,7 @@ import rapido.souper
 from rapido.core.interfaces import IRapidoApplication
 import rapido.core.tests
 from rapido.core.tests.base import SiteNode, SimpleRapidoApplication
+from chameleon import PageTemplate
 
 
 class TestCase(unittest.TestCase):
@@ -198,5 +199,31 @@ def author(context):
         block = self.app.get_block('block10')
         self.assertIn(
             "You know nothing, John Snow",
+            block.display(None)
+        )
+
+    def test_on_display_noelements(self):
+        self.app_obj.fake_blocks['noelements1'] = {'py': """
+def on_display(context):
+    return ["text/html", "John Snow"]
+"""}
+
+        block = self.app.get_block('noelements1')
+        self.assertIn(
+            "John Snow",
+            block.display(None)
+        )
+
+    def test_on_display_noelements_zpt(self):
+        self.app_obj.fake_blocks['noelements1'] = {'py': """
+def on_display(context):
+    return {'myelement':'John Snow'}
+""",
+                                                   'html': PageTemplate("""
+<html><body>${myelement}</body></html>""")}
+
+        block = self.app.get_block('noelements1')
+        self.assertIn(
+            "John Snow",
             block.display(None)
         )

--- a/rapido/core/tests/test_record.py
+++ b/rapido/core/tests/test_record.py
@@ -146,10 +146,10 @@ acl:
             'weight': 3.2,
         })
         html = block.display(record, edit=True)
-        self.assertTrue('<input type="number"\n'
-            '        name="year" value="1845" />' in html)
-        self.assertTrue('<input type="number"\n'
-            '        name="weight" value="3.2" />' in html)
+        self.assertIn('<input type="number"\n'
+            '        name="year" value="1845" />', html)
+        self.assertIn('<input type="number"\n'
+            '        name="weight" value="3.2" />', html)
 
     def test_render_datetime_elements(self):
         self.app_obj.set_fake_block_data('frmBook', 'html', """Author: {author}
@@ -158,15 +158,15 @@ acl:
             del self.app._blocks['frmBook']
         block = self.app.get_block('frmBook')
         html = block.display(None, edit=True)
-        self.assertTrue('<input type="date"\n'
-            '        name="publication" value="" />' in html)
+        self.assertIn('<input type="date"\n'
+            '        name="publication" value="" />', html)
         record = self.app.create_record()
         record.save({
             'publication': datetime.strptime('2015-11-15', "%Y-%m-%d"),
         })
         html = block.display(record, edit=True)
-        self.assertTrue('<input type="date"\n'
-            '        name="publication" value="2015-11-15" />' in html)
+        self.assertIn('<input type="date"\n'
+            '        name="publication" value="2015-11-15" />', html)
 
     def test_compute_element_using_record_data(self):
         block = self.app.get_block('frmBook7')

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ setup(name='rapido.core',
         'test': [
             'plone.app.testing',
             'rapido.souper',
+            'zope.annotation',
+            'chameleon'
         ],
       },
       entry_points="""


### PR DESCRIPTION
trying to solve https://github.com/plomino/rapido.core/issues/21. 
Able to create simple blocks that return whatever you want, no template or elements needed.
Also made zpt simpler by allowing ${element} and ${python: element(myarg=1)

Will likely change on_display to on_init and make sure its called on every @@block request.